### PR TITLE
Secure API key storage and improve AI service reliability

### DIFF
--- a/mobile_app/App.js
+++ b/mobile_app/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { StatusBar } from 'expo-status-bar';
@@ -11,6 +11,7 @@ import CameraScreen from './src/screens/CameraScreen';
 import VoiceScreen from './src/screens/VoiceScreen';
 import LocationScreen from './src/screens/LocationScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
+import AIService from './src/services/AIService';
 
 // Theme configuration
 const theme = {
@@ -31,6 +32,25 @@ function TabIcon({ name, color, size }) {
 }
 
 export default function App() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        await AIService.initialize();
+      } catch (e) {
+        console.error('AIService initialization failed', e);
+      } finally {
+        setReady(true);
+      }
+    };
+    init();
+  }, []);
+
+  if (!ready) {
+    return null;
+  }
+
   return (
     <PaperProvider theme={theme}>
       <NavigationContainer>

--- a/mobile_app/package.json
+++ b/mobile_app/package.json
@@ -26,6 +26,7 @@
     "expo-location": "~16.1.0",
     "expo-permissions": "~14.2.1",
     "expo-linear-gradient": "~12.3.0",
+    "expo-secure-store": "~12.3.0",
     "react-native-vector-icons": "^10.0.0",
     "@expo/vector-icons": "^13.0.0",
     "react-native-paper": "^5.10.0",
@@ -35,7 +36,8 @@
     "expo-image-picker": "~14.3.2",
     "expo-document-picker": "~11.5.4",
     "react-native-gesture-handler": "~2.12.0",
-    "@react-native-async-storage/async-storage": "1.18.2"
+    "@react-native-async-storage/async-storage": "1.18.2",
+    "@react-native-community/netinfo": "^9.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile_app/src/screens/VoiceScreen.js
+++ b/mobile_app/src/screens/VoiceScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Animated } from 'react-native';
 import { Button, Card, Title, Paragraph, Switch } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
@@ -15,7 +15,7 @@ export default function VoiceScreen() {
   const [recording, setRecording] = useState(null);
   const [autoSpeak, setAutoSpeak] = useState(true);
   const [hasAudioPermission, setHasAudioPermission] = useState(null);
-  const pulseAnim = new Animated.Value(1);
+  const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
     requestAudioPermissions();
@@ -28,6 +28,17 @@ export default function VoiceScreen() {
       stopPulseAnimation();
     }
   }, [isListening]);
+
+  useEffect(() => {
+    return () => {
+      stopPulseAnimation();
+      if (recording) {
+        try {
+          recording.stopAndUnloadAsync();
+        } catch {}
+      }
+    };
+  }, [recording]);
 
   const requestAudioPermissions = async () => {
     try {


### PR DESCRIPTION
## Summary
- Protect OpenAI API key using expo-secure-store and validate key input in settings.
- Initialize AIService on app startup and use NetInfo for offline detection with safe fallbacks.
- Persist voice screen animations and clean up audio resources on unmount.

## Testing
- `npm test` *(fails: Missing script "test" because no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ab9d4298832790969b60bde6633c